### PR TITLE
Update : 0.3.11.2

### DIFF
--- a/CM3D2.VMDPlay.Plugin/CM3D2.VMDPlay.Plugin/VMDAnimationController.cs
+++ b/CM3D2.VMDPlay.Plugin/CM3D2.VMDPlay.Plugin/VMDAnimationController.cs
@@ -1,3 +1,4 @@
+using CM3D2.VMDPlay.Plugin.Utill;
 using COM3D2.Lilly.Plugin;
 using COM3D2.Lilly.Plugin.Utill;
 using MMD.VMD;
@@ -36,57 +37,194 @@ namespace CM3D2.VMDPlay.Plugin
 		{
 			private VMDAnimationController mgr;
 
-			private float _shoulder = 10f;
+			private float[] _shoulder = {0,0,0}; //{-15f, -20f, 0f};
 
-			private float _armUp = 30f;
+			private float[] _armUp = {0,0,40}; //40f;
 
-			private float _armLow;
+			private float[] _armLow = {0,0,0}; //10f;
 
 			private float _scaleModel = 1f;
 
-			public float Shoulder
+			public int AdjustCount()
+			{
+				const int count = 10;
+				return count;
+			}
+			public float[] ConvertToArray()
+			{
+				var adjustParams = new float[AdjustCount()];
+				adjustParams[0] = _shoulder[0];
+				adjustParams[1] = _shoulder[1];
+				adjustParams[2] = _shoulder[2];
+				adjustParams[3] = _armUp[0];
+				adjustParams[4] = _armUp[1];
+				adjustParams[5] = _armUp[2];
+				adjustParams[6] = _armLow[0];
+				adjustParams[7] = _armLow[1];
+				adjustParams[8] = _armLow[2];
+				adjustParams[9] = _scaleModel;
+				return adjustParams;
+			}
+
+			internal void ParseAdjust(SongMotionUtill.motionAndTime mat)
+            {
+				if(mat.adjustParams == null) return;
+				
+                int dstCount = mat.adjustParams.Count();
+				int srcCount = AdjustCount();
+
+				if(srcCount > dstCount)	return;
+				_shoulder[0] = mat.adjustParams[0];
+				_shoulder[1] = mat.adjustParams[1];
+				_shoulder[2] = mat.adjustParams[2];
+				_armUp[0] = mat.adjustParams[3];
+				_armUp[1] = mat.adjustParams[4];
+				_armUp[2] = mat.adjustParams[5];
+				_armLow[0] = mat.adjustParams[6];
+				_armLow[1] = mat.adjustParams[7];
+				_armLow[2] = mat.adjustParams[8];
+				_scaleModel = mat.adjustParams[9];
+
+				Set();
+            }
+
+			public float ShoulderX
 			{
 				get
 				{
-					return _shoulder;
+					return _shoulder[0];
 				}
 				set
 				{
-					if (_shoulder != value)
+					if (_shoulder[0] != value)
 					{
-						_shoulder = value;
+						_shoulder[0] = value;
+						Set();
+					}
+				}
+			}
+			public float ShoulderY
+			{
+				get
+				{
+					return _shoulder[1];
+				}
+				set
+				{
+					if (_shoulder[1] != value)
+					{
+						_shoulder[1] = value;
+						Set();
+					}
+				}
+			}
+			public float ShoulderZ
+			{
+				get
+				{
+					return _shoulder[2];
+				}
+				set
+				{
+					if (_shoulder[2] != value)
+					{
+						_shoulder[2] = value;
 						Set();
 					}
 				}
 			}
 
-			public float ArmUp
+			public float ArmUpX
 			{
 				get
 				{
-					return _armUp;
+					return _armUp[0];
 				}
 				set
 				{
-					if (_armUp != value)
+					if (_armUp[0] != value)
 					{
-						_armUp = value;
+						_armUp[0] = value;
 						Set();
 					}
 				}
 			}
 
-			public float ArmLow
+			public float ArmUpY
 			{
 				get
 				{
-					return _armLow;
+					return _armUp[1];
 				}
 				set
 				{
-					if (_armLow != value)
+					if (_armUp[1] != value)
 					{
-						_armLow = value;
+						_armUp[1] = value;
+						Set();
+					}
+				}
+			}
+
+			public float ArmUpZ
+			{
+				get
+				{
+					return _armUp[2];
+				}
+				set
+				{
+					if (_armUp[2] != value)
+					{
+						_armUp[2] = value;
+						Set();
+					}
+				}
+			}
+
+			public float ArmLowX
+			{
+				get
+				{
+					return _armLow[0];
+				}
+				set
+				{
+					if (_armLow[0] != value)
+					{
+						_armLow[0] = value;
+						Set();
+					}
+				}
+			}
+
+			public float ArmLowY
+			{
+				get
+				{
+					return _armLow[1];
+				}
+				set
+				{
+					if (_armLow[1] != value)
+					{
+						_armLow[1] = value;
+						Set();
+					}
+				}
+			}
+
+			public float ArmLowZ
+			{
+				get
+				{
+					return _armLow[2];
+				}
+				set
+				{
+					if (_armLow[2] != value)
+					{
+						_armLow[2] = value;
 						Set();
 					}
 				}
@@ -117,16 +255,16 @@ namespace CM3D2.VMDPlay.Plugin
 			{
 				try
 				{
-					mgr.boneAdjust[mgr._shoulderKey[0]].SetRotAdjustment(new Vector3(0f, 0f, _shoulder));
-					mgr.boneAdjust[mgr._shoulderKey[1]].SetRotAdjustment(new Vector3(0f, 0f, -1f * _shoulder));
-					mgr.boneAdjust[mgr._armUpKey[0]].SetRotAdjustment(new Vector3(0f, 0f, _armUp));
-					mgr.boneAdjust[mgr._armUpKey[1]].SetRotAdjustment(new Vector3(0f, 0f, -1f * _armUp));
-					mgr.boneAdjust[mgr._armLowKey[0]].SetRotAdjustment(new Vector3(0f, 0f, _armLow));
-					mgr.boneAdjust[mgr._armLowKey[1]].SetRotAdjustment(new Vector3(0f, 0f, -1f * _armLow));
-					mgr.boneAdjust[mgr._armUpKey[0]].SetAxisAdjustment(new Vector3(0f, 0f, -1f * _shoulder));
-					mgr.boneAdjust[mgr._armUpKey[1]].SetAxisAdjustment(new Vector3(0f, 0f, _shoulder));
-					mgr.boneAdjust[mgr._armLowKey[0]].SetAxisAdjustment(new Vector3(0f, 0f, -1f * _armUp));
-					mgr.boneAdjust[mgr._armLowKey[1]].SetAxisAdjustment(new Vector3(0f, 0f, _armUp));
+					mgr.boneAdjust[mgr._shoulderKey[0]].SetRotAdjustment(new Vector3(_shoulder[0], _shoulder[1], _shoulder[2]));
+					mgr.boneAdjust[mgr._shoulderKey[1]].SetRotAdjustment(new Vector3(_shoulder[0], -1f * _shoulder[1], -1f * _shoulder[2]));
+					mgr.boneAdjust[mgr._armUpKey[0]].SetRotAdjustment(new Vector3(_armUp[0], _armUp[1], _armUp[2]));
+					mgr.boneAdjust[mgr._armUpKey[1]].SetRotAdjustment(new Vector3(_armUp[0], -1 * _armUp[1], -1f * _armUp[2]));
+					mgr.boneAdjust[mgr._armLowKey[0]].SetRotAdjustment(new Vector3(_armLow[0], -1 * _armLow[1], _armLow[2]));
+					mgr.boneAdjust[mgr._armLowKey[1]].SetRotAdjustment(new Vector3(_armLow[0], -1 * _armLow[1], -1f * _armLow[2]));
+					mgr.boneAdjust[mgr._armUpKey[0]].SetAxisAdjustment(new Vector3(_shoulder[0], -1f * _shoulder[1], -1f * _shoulder[2]));
+					mgr.boneAdjust[mgr._armUpKey[1]].SetAxisAdjustment(new Vector3(_shoulder[0], _shoulder[1], _shoulder[2]));
+					mgr.boneAdjust[mgr._armLowKey[0]].SetAxisAdjustment(new Vector3(_armUp[0], -1 * _armUp[1], -1f * _armUp[2]));
+					mgr.boneAdjust[mgr._armLowKey[1]].SetAxisAdjustment(new Vector3(_armUp[0], _armUp[1], _armUp[2]));
 					mgr.scale = mgr.scaleBase * _scaleModel;
 				}
 				catch (Exception value)
@@ -134,7 +272,7 @@ namespace CM3D2.VMDPlay.Plugin
 					Console.WriteLine(value);
 				}
 			}
-		}
+        }
 
 		public class AutoTrack : UnityEngine.MonoBehaviour
 		{

--- a/CM3D2.VMDPlay.Plugin/CM3D2.VMDPlay.Plugin/VMDHSConverter.cs
+++ b/CM3D2.VMDPlay.Plugin/CM3D2.VMDPlay.Plugin/VMDHSConverter.cs
@@ -495,7 +495,7 @@ namespace CM3D2.VMDPlay.Plugin
 						Quaternion val = Quaternion.identity;
 						for (int i = 0; i < list.Count; i++)
 						{
-							float num = (float)(double)list[i].flame_no * 0.0333333351f;
+							float num = (float)(double)list[i].frame_no * 0.0333333351f; // 1 / 30 fos
 							Quaternion val2 = list[i].rotation;
 							if (dictionary != null)
 							{
@@ -698,7 +698,7 @@ namespace CM3D2.VMDPlay.Plugin
 						int index3 = 0;
 						for (int i = 0; i < list.Count; i++)
 						{
-							float num = (float)(double)list[i].flame_no * 0.0333333351f;
+							float num = (float)(double)list[i].frame_no * 0.0333333351f; // 1 / 30 fps
 							Vector3 val2 = list[i].location;
 							if (!(val2 == Vector3.zero))
 							{
@@ -844,7 +844,7 @@ namespace CM3D2.VMDPlay.Plugin
 			int index3 = 0;
 			for (int i = 0; i < list.Count; i++)
 			{
-				float time = (float)(double)list[i].flame_no * 0.0333333351f;
+				float time = (float)(double)list[i].frame_no * 0.0333333351f; // (1 / 30.0 fps)
 				FloatKeyframe floatKeyframe = new FloatKeyframe(time, list[i].location.x * scale + (zero).x);
 				FloatKeyframe floatKeyframe2 = new FloatKeyframe(time, list[i].location.y * scale + (zero).y);
 				FloatKeyframe floatKeyframe3 = new FloatKeyframe(time, list[i].location.z * scale + (zero).z);
@@ -872,7 +872,7 @@ namespace CM3D2.VMDPlay.Plugin
 			int index4 = 0;
 			for (int j = 0; j < list.Count; j++)
 			{
-				float time2 = (float)(double)list[j].flame_no * 0.0333333351f;
+				float time2 = (float)(double)list[j].frame_no * 0.0333333351f; // (1 / 30.0 fps)
 				Quaternion rotation = list[j].rotation;
 				QuaternionKeyframe quaternionKeyframe = new QuaternionKeyframe(time2, rotation);
 				QuaternionKeyframe.AddBezierKeyframes(list[j].interpolation, 3, prev_keyframe4, quaternionKeyframe, interpolationQuality, ref keyframes4, ref index4);

--- a/CM3D2.VMDPlay.Plugin/COM3D2.VMDPlay.Plugin.csproj
+++ b/CM3D2.VMDPlay.Plugin/COM3D2.VMDPlay.Plugin.csproj
@@ -36,10 +36,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>H:\COM3D2\COM3D2x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\packages\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\packages\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="COM3D2.API">
-      <HintPath>H:\COM3D2\BepinEx\plugins\COM3D2.API.dll</HintPath>
+      <HintPath>..\packages\COM3D2.API.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -49,6 +52,9 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="UnityEditor">
+      <HintPath>..\packages\UnityEditor.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BoneController.cs" />
@@ -126,7 +132,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(targetpath)" "h:\COM3D2\BepInEx\plugins" 
-copy "$(targetpath)" "h:\COM3D2-test\BepInEx\plugins"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/CM3D2.VMDPlay.Plugin/GUIUtill/CM3D2VMDGUI.cs
+++ b/CM3D2.VMDPlay.Plugin/GUIUtill/CM3D2VMDGUI.cs
@@ -261,7 +261,7 @@ namespace CM3D2.VMDPlay.Plugin
         }
 
         /// <summary>
-        /// ÃÖÀûÈ­ ¿Ï·á?
+        /// ï¿½ï¿½ï¿½ï¿½È­ ï¿½Ï·ï¿½?
         /// </summary>
         /// <returns></returns>
         private Maid FindFirstMaid()
@@ -285,7 +285,7 @@ namespace CM3D2.VMDPlay.Plugin
         }
 
         /// <summary>
-        /// ÃÖÀûÈ­ ¿Ï·á?
+        /// ï¿½ï¿½ï¿½ï¿½È­ ï¿½Ï·ï¿½?
         /// </summary>
         /// <param name="next"></param>
         /// <returns></returns>
@@ -377,7 +377,7 @@ namespace CM3D2.VMDPlay.Plugin
                     FavoritesName
                     , oggFilename
                     //, VMDAnimationMgr.Instance.controllers.Where(x=> CharacterMgrPatch.maids.Contains(x.maid) ).Select(x => x.lastLoadedVMD).ToArray()
-                    , VMDAnimationMgr.Instance.maidcontrollers.Values.Select(x => new SongMotionUtill.motionAndTime(x.lastLoadedVMD , x.timeShiftNow)).ToArray()
+                    , VMDAnimationMgr.Instance.maidcontrollers.Values.Select(x => new SongMotionUtill.motionAndTime(x.lastLoadedVMD , x.timeShiftNow, x.quickAdjust.ConvertToArray(), x.quickAdjust.AdjustCount())).ToArray()
                     );
                // MyLog.LogMessage("add", VMDAnimationMgr.Instance.controllers.Count, CharacterMgrPatch.maids.Count, VMDAnimationMgr.Instance.controllers.Where(x => CharacterMgrPatch.maids.Contains(x.maid)).Count() );
                 MyLog.LogMessage("add", VMDAnimationMgr.Instance.maidcontrollers.Count, CharacterMgrPatch.maids.Count);
@@ -417,6 +417,7 @@ namespace CM3D2.VMDPlay.Plugin
                                 vMDAnimationControllerSub.VMDAnimEnabled = true;
                                 vMDAnimationControllerSub.timeShiftNow = item.Value.Motions2[i].time;
                                 vMDAnimationControllerSub.LoadVMDAnimation(item.Value.Motions2[i].motion);
+                                vMDAnimationControllerSub.quickAdjust.ParseAdjust(item.Value.Motions2[i]);
                             }
                             //vMDAnimationController = VMDAnimationController.Install(focusChara);
                             lastFilename = vMDAnimationController.lastLoadedVMD ;
@@ -428,11 +429,12 @@ namespace CM3D2.VMDPlay.Plugin
                         //{
                         //    vMDAnimationController.Play();
                         //}
-                        VMDAnimationMgr.Instance.PlayAll();
-                        AudioManager.Play();
+
+                        // VMDAnimationMgr.Instance.PlayAll();
+                        // AudioManager.Play();
                         
-                        isFavorites = false;
-                        this.gameObject.SetActive(false);
+                        // isFavorites = false;
+                        // this.gameObject.SetActive(false);
                     }
                     if (GUILayout.Button("Del", gui[50f, 25f]))
                     {
@@ -489,7 +491,7 @@ namespace CM3D2.VMDPlay.Plugin
 
                 if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                 {
-                    // À½¾ÇÀº »ó´ë°æ·Î°¡ ¾È¸ÔÈù´Ù?
+                    // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Î°ï¿½ ï¿½È¸ï¿½ï¿½ï¿½ï¿½ï¿½?
                     oggFilename = MyUtill.EvaluateRelativePath(Environment.CurrentDirectory, dialog.FileName);
                     if (vMDAnimationController != null)
                     {
@@ -834,13 +836,31 @@ namespace CM3D2.VMDPlay.Plugin
                         }
                         GUILayout.EndHorizontal();
                         GUILayout.BeginHorizontal( );
-                        vMDAnimationController.quickAdjust.Shoulder = AddSliderWithTextFixedScale("Shoulder Tilt", vMDAnimationController.quickAdjust.Shoulder, -10f, 40f);
+                        vMDAnimationController.quickAdjust.ShoulderX = AddSliderWithTextFixedScale("Shoulder TiltX", vMDAnimationController.quickAdjust.ShoulderX, -20f, 40f);
                         GUILayout.EndHorizontal();
                         GUILayout.BeginHorizontal( );
-                        vMDAnimationController.quickAdjust.ArmUp = AddSliderWithTextFixedScale("Upper Arm Tilt", vMDAnimationController.quickAdjust.ArmUp, -10f, 40f);
+                        vMDAnimationController.quickAdjust.ShoulderY = AddSliderWithTextFixedScale("Shoulder TiltY", vMDAnimationController.quickAdjust.ShoulderY, -20f, 40f);
                         GUILayout.EndHorizontal();
                         GUILayout.BeginHorizontal( );
-                        vMDAnimationController.quickAdjust.ArmLow = AddSliderWithTextFixedScale("Lower Arm Tilt", vMDAnimationController.quickAdjust.ArmLow, -10f, 40f);
+                        vMDAnimationController.quickAdjust.ShoulderZ = AddSliderWithTextFixedScale("Shoulder TiltZ", vMDAnimationController.quickAdjust.ShoulderZ, -20f, 40f);
+                        GUILayout.EndHorizontal();
+                        GUILayout.BeginHorizontal( );
+                        vMDAnimationController.quickAdjust.ArmUpX = AddSliderWithTextFixedScale("Upper Arm TiltX", vMDAnimationController.quickAdjust.ArmUpX, -20f, 40f);
+                        GUILayout.EndHorizontal();
+                        GUILayout.BeginHorizontal( );
+                        vMDAnimationController.quickAdjust.ArmUpY = AddSliderWithTextFixedScale("Upper Arm TiltY", vMDAnimationController.quickAdjust.ArmUpY, -20f, 40f);
+                        GUILayout.EndHorizontal();
+                        GUILayout.BeginHorizontal( );
+                        vMDAnimationController.quickAdjust.ArmUpZ = AddSliderWithTextFixedScale("Upper Arm TiltZ", vMDAnimationController.quickAdjust.ArmUpZ, -20f, 40f);
+                        GUILayout.EndHorizontal();
+                        GUILayout.BeginHorizontal( );
+                        vMDAnimationController.quickAdjust.ArmLowX = AddSliderWithTextFixedScale("Lower Arm TiltX", vMDAnimationController.quickAdjust.ArmLowX, -20f, 40f);
+                        GUILayout.EndHorizontal();
+                        GUILayout.BeginHorizontal( );
+                        vMDAnimationController.quickAdjust.ArmLowY = AddSliderWithTextFixedScale("Lower Arm TiltY", vMDAnimationController.quickAdjust.ArmLowY, -20f, 40f);
+                        GUILayout.EndHorizontal();
+                        GUILayout.BeginHorizontal( );
+                        vMDAnimationController.quickAdjust.ArmLowZ = AddSliderWithTextFixedScale("Lower Arm TiltZ", vMDAnimationController.quickAdjust.ArmLowZ, -20f, 40f);
                         GUILayout.EndHorizontal();
                         //GUILayout.Label("Other Config", (GUILayoutOption[])new GUILayoutOption[1]
                         //{

--- a/CM3D2.VMDPlay.Plugin/GUIUtill/CM3D2VMDGUI2.cs
+++ b/CM3D2.VMDPlay.Plugin/GUIUtill/CM3D2VMDGUI2.cs
@@ -381,7 +381,7 @@ namespace CM3D2.VMDPlay.Plugin
 				obj.color = Color.white;
 				obj.trueTypeFont = font;
 				obj.fontSize = 18;
-				obj.text = "COM3D2.VMDPlay.Plugin 0.3.11.0";
+				obj.text = "COM3D2.VMDPlay.Plugin 0.3.11.2";
 
 
 				float num2 = (float)uiBGSprite.height / 2f;

--- a/CM3D2.VMDPlay.Plugin/MMD.VMD/VMDFormat.cs
+++ b/CM3D2.VMDPlay.Plugin/MMD.VMD/VMDFormat.cs
@@ -57,7 +57,7 @@ namespace MMD.VMD
 		{
 			public string bone_name;
 
-			public uint flame_no;
+			public uint frame_no;
 
 			public Vector3 location;
 
@@ -72,11 +72,11 @@ namespace MMD.VMD
 				//IL_0036: Unknown result type (might be due to invalid IL or missing references)
 				//IL_003b: Unknown result type (might be due to invalid IL or missing references)
 				bone_name = ConvertByteToString(bin.ReadBytes(15));
-				flame_no = bin.ReadUInt32();
+				frame_no = bin.ReadUInt32();
 				location = ReadSinglesToVector3(bin);
 				rotation = ReadSinglesToQuaternion(bin);
 				interpolation = bin.ReadBytes(64);
-				count = (int)flame_no;
+				count = (int)frame_no;
 			}
 
 			public byte GetInterpolation(int i, int j, int k)

--- a/CM3D2.VMDPlay.Plugin/Main/CM3D2VMDPlugin.cs
+++ b/CM3D2.VMDPlay.Plugin/Main/CM3D2VMDPlugin.cs
@@ -16,7 +16,7 @@ namespace CM3D2.VMDPlay.Plugin
 	//[PluginName("COM3D2.VMDPlay.Plugin")]
 	//[PluginVersion("0.3.11.0")]
 
-	[BepInPlugin("COM3D2.VMDPlay.Plugin", "COM3D2.VMDPlay.Plugin", "0.3.11.0")]// ¹öÀü ±ÔÄ¢ ÀÕÀ½. ¹Ýµå½Ã 2~4°³ÀÇ ¼ýÀÚ±¸¼ºÀ¸·Î ÇØ¾ßÇÔ. ¹ÌÁØ¼ö½Ã ¸øÀÐ¾îµéÀÓ
+	[BepInPlugin("COM3D2.VMDPlay.Plugin", "COM3D2.VMDPlay.Plugin", "0.3.11.2")]// ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Ä¢ ï¿½ï¿½ï¿½ï¿½. ï¿½Ýµï¿½ï¿½ 2~4ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Ú±ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ø¾ï¿½ï¿½ï¿½. ï¿½ï¿½ï¿½Ø¼ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Ð¾ï¿½ï¿½ï¿½ï¿½
 	[BepInProcess("COM3D2x64.exe")]
 	public class CM3D2VMDPlugin : BaseUnityPlugin//UnityInjector.PluginBase
 	{
@@ -24,7 +24,7 @@ namespace CM3D2.VMDPlay.Plugin
 
 		public const string NAME = "COM3D2.VMDPlay.Plugin";
 
-		public const string VERSION = "0.3.11.0";
+		public const string VERSION = "0.3.11.2";
 
 		public CM3D2VMDPlugin()
         {

--- a/CM3D2.VMDPlay.Plugin/Main/VMDAnimationController.cs
+++ b/CM3D2.VMDPlay.Plugin/Main/VMDAnimationController.cs
@@ -274,7 +274,7 @@ namespace CM3D2.VMDPlay.Plugin
 
 		public bool enableIK = true;
 
-		// 뼈가 없는 경우 대비한듯
+		// 뼈가 없는 경우 대비한듯 // unity bone 이름 <-> mms 본이름(shift-jis) 매핑
 		public Dictionary<string, string> boneNameMap;
 
 		private Transform t_hips;

--- a/CM3D2.VMDPlay.Plugin/Utill/SongMotionUtill.cs
+++ b/CM3D2.VMDPlay.Plugin/Utill/SongMotionUtill.cs
@@ -15,11 +15,19 @@ namespace CM3D2.VMDPlay.Plugin.Utill
         {
             public string motion;
             public float time;
+            public float[] adjustParams;
 
-            public motionAndTime(string motion, float time)
+            public motionAndTime(string motion, float time, float[] adjust = null, int count=0)
             {
                 this.motion = motion??string.Empty;
                 this.time = time;
+
+                if(adjust != null && count > 0) {
+                    this.adjustParams = new float[count];
+                    for(int i=0;i<count;++i)
+                        this.adjustParams[i] = adjust[i];
+                }
+                else this.adjustParams = null;
             }
         }
 

--- a/COM3D25.VMDPlay.Plugin/COM3D25.VMDPlay.Plugin.csproj
+++ b/COM3D25.VMDPlay.Plugin/COM3D25.VMDPlay.Plugin.csproj
@@ -234,8 +234,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(targetpath)" "h:\COM3D2_5\BepInEx\plugins" 
-copy "$(targetpath)" "h:\COM3D2_5-test\BepInEx\plugins"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\BepInEx.Core.5.4.19\build\BepInEx.Core.targets" Condition="Exists('..\packages\BepInEx.Core.5.4.19\build\BepInEx.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/README.MD
+++ b/README.MD
@@ -3,6 +3,13 @@
 단순하게 베핀용으로 바꾼거  
 그리고 취향에 맞게 개조중  
 
+# Change Log : 0.3.11.2
+ - COM3D2.VMDPlay.Plugin 업데이트
+   - 어깨, 팔상하박 XYZ 회전 QuickAdjust 추가
+   - Favorite 에 QuickAdjust 파라미터 저장/불러오기 포함
+     - 총 10개 파라미터 : 어째, 상박, 하박 XYZ, 모델 scale
+   - Load 시에 윈도우 숨김 기능 제거
+
 
 # 개조한거
 
@@ -24,7 +31,9 @@ https://youtu.be/LHRlHhz0dEM
 
 - BepInEx https://github.com/BepInEx/BepInEx  
 - COM3D2.API.dll  https://github.com/DeathWeasel1337/COM3D2_Plugins/releases/download/v3/COM3D2.API.v1.0.zip  
-
+- UnityEngine.dll (5.6.1)
+- Assembly-CSharp.dll (COM3D2\COM3D2x64_Data\Managed)
+- Assembly-CSharp-firstpass.dll (COM3D2\COM3D2x64_Data\Managed)
 
 # 참고
 


### PR DESCRIPTION
뒤늦게 커오메 접하고 있습니다.
최근에는 댄카모를 많이들 쓰시는거 같긴 한데, 직접 VMD 돌리기에는 복잡한 단계를 거쳐야 해서
상대적으로 간단한 VMDPlay 가 편하다고 생각됩니다.
(VMDPlay의 댄스 품질이 낮고, 변수 조작에 공을 들여야 하는 부분이 있지만...)
다만 시험삼아 몇 개 VMD 올려 보니, QuickAdjst 부분의 축이 하나 밖에 없어 조작에 제한이 있는 것을 확인하였습니다.
Lily 님이 베핀용 소스 코드 공개하신게 있어서 해당 코드를 바탕으로 기능을 추가해보았습니다.
커오메 2.2 에서 테스트 해보았고 현재 딱히 업데이트는 없으신 것으로 파악되어 PR 한 번 요청해봅니다.

빌드 버전 파일도 추가합니다.
[COM3D2.VMDPlay.Plugin.zip](https://github.com/customordermaid3d2/CM3D2.VMDPlay.Plugin/files/9639156/COM3D2.VMDPlay.Plugin.zip)


업데이트 내용은 대략 아래와 같습니다.
----------
COM3D2.VMDPlay.Plugin 업데이트
   - 어깨, 팔상하박 XYZ 회전 QuickAdjust 추가
   - Favorite 에 QuickAdjust 파라미터 저장/불러오기 favorite에 포함
    - 총 10개 파라미터 : 어째, 상박, 하박 XYZ, 모델 scale
   - Load 시에 윈도우 숨김 기능 제거